### PR TITLE
Add skeleton for unimplemented pure virtual method in OpenGLGraphics

### DIFF
--- a/include/fifechan/opengl/openglgraphics.hpp
+++ b/include/fifechan/opengl/openglgraphics.hpp
@@ -149,9 +149,23 @@ namespace fcn
 
         virtual void drawLine(int x1, int y1, int x2, int y2);
 
+        virtual void drawLine(int x1, int y1, int x2, int y2, unsigned int width);
+
+        virtual void drawPolyLine(const PointVector& points, unsigned int width);
+
+        virtual void drawBezier(const PointVector& points, int steps, unsigned int width);
+
         virtual void drawRectangle(const Rectangle& rectangle);
 
         virtual void fillRectangle(const Rectangle& rectangle);
+
+        virtual void drawCircle(const Point& p, unsigned int radius);
+
+        virtual void drawFillCircle(const Point& p, unsigned int radius);
+
+        virtual void drawCircleSegment(const Point& p, unsigned int radius, int sangle, int eangle);
+
+        virtual void drawFillCircleSegment(const Point& p, unsigned int radius, int sangle, int eangle);
 
         virtual void setColor(const Color& color);
 

--- a/src/opengl/openglgraphics.cpp
+++ b/src/opengl/openglgraphics.cpp
@@ -321,6 +321,21 @@ namespace fcn
         glEnd();
     }
 
+    void OpenGLGraphics::drawLine(int x1, int y1, int x2, int y2, unsigned int width)
+    {
+        // TODO
+    }
+
+    void OpenGLGraphics::drawPolyLine(const PointVector& points, unsigned int width)
+    {
+        // TODO
+    }
+
+    void OpenGLGraphics::drawBezier(const PointVector& points, int steps, unsigned int width)
+    {
+        // TODO
+    }
+
     void OpenGLGraphics::drawRectangle(const Rectangle& rectangle)
     {
         if (mClipStack.empty())
@@ -361,6 +376,26 @@ namespace fcn
         glVertex2i(rectangle.x + top.xOffset,
                    rectangle.y + rectangle.height + top.yOffset);
         glEnd();
+    }
+
+    void OpenGLGraphics::drawCircle(const Point& p, unsigned int radius)
+    {
+        // TODO
+    }
+
+    void OpenGLGraphics::drawFillCircle(const Point& p, unsigned int radius)
+    {
+        // TODO
+    }
+
+    void OpenGLGraphics::drawCircleSegment(const Point& p, unsigned int radius, int sangle, int eangle)
+    {
+        // TODO
+    }
+
+    void OpenGLGraphics::drawFillCircleSegment(const Point& p, unsigned int radius, int sangle, int eangle)
+    {
+        // TODO
     }
 
     void OpenGLGraphics::setColor(const Color& color)


### PR DESCRIPTION
As mentioned in #56, compiling the simple fifechan-demo on macOS 10.15 fails with the following error:
```allocating an object of abstract class type 'fcn::OpenGLGraphics'.```
This is followed by a list of 7 unimplemented functions of OpenGLGraphics.

This commit adds function declarations and empty bodies to prevent
mentioned compiler error for now. This is not ideal, but since nobody
was missing those functions so far, I doubt they are used anywhere.